### PR TITLE
multi-line commands support (UART tested only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ ${CMAKE_CURRENT_SOURCE_DIR}/callbackmanager
 )
 
 # select the communication protocol to talk to the Teseo GPS
-#add_compile_definitions(GPS_OVER_UART)
-add_compile_definitions(GPS_OVER_I2C)
+add_compile_definitions(GPS_OVER_UART)
+#add_compile_definitions(GPS_OVER_I2C)
 
 # select the debug output (not used by the GPS interface)
 pico_enable_stdio_uart(${CMAKE_PROJECT_NAME} 1)

--- a/Doxyfile
+++ b/Doxyfile
@@ -1084,7 +1084,7 @@ USE_MDFILE_AS_MAINPAGE =
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # classes and enums directly into the documentation.

--- a/callbackmanager/callbackmanager.h
+++ b/callbackmanager/callbackmanager.h
@@ -12,7 +12,6 @@
 
 template <typename R, typename... Args>
 // restrict to arithmetic data types for return value, or void
-// restrict to arithmetic data types for return value, or void
 #ifdef __GNUC__ // this requires a recent version of GCC.
 #if __GNUC_PREREQ(10,0)
   requires std::is_void<R>::value || std::is_arithmetic_v<R>

--- a/main.cpp
+++ b/main.cpp
@@ -59,8 +59,11 @@
 #define UART_BAUD (9600)
 #define UART_TX (4)
 #define UART_RX (5)
-#define BUFFSIZE (180)
-#define UART_WAITFORREPLY_MS (200)
+// multiline replies take decent buffer size
+#define BUFFSIZE (1024)
+// multiline replies take a while at 9600 baud. 
+// 400 ms is not enough for commands like GPGSV
+#define UART_WAITFORREPLY_MS (500)
 // forward declaration
 void on_uart_rx();
 int UART_IRQ = UART1_IRQ;
@@ -231,9 +234,9 @@ int main() {
         printf(reply.c_str());
 
         // TODO: ggsv returns multiple lines
-        gps.ask_gpgsv(replies, 4);
-        for (auto &reply : replies) {
-            printf(reply.c_str());
+        gps.ask_gpgsv(replies);
+        for (auto &s : replies) {
+            printf(s.c_str());
         }
 
         gps.ask_gprmc(reply, 4);

--- a/main.cpp
+++ b/main.cpp
@@ -233,11 +233,12 @@ int main() {
         gps.ask_gpgll(reply, 4);
         printf(reply.c_str());
 
-        // TODO: ggsv returns multiple lines
+#ifdef GPS_OVER_UART // not tested with I2C
         gps.ask_gpgsv(replies);
         for (auto &s : replies) {
             printf(s.c_str());
         }
+#endif
 
         gps.ask_gprmc(reply, 4);
         printf(reply.c_str());

--- a/teseo/teseo.cpp
+++ b/teseo/teseo.cpp
@@ -3,6 +3,7 @@
 namespace teseo {
 
 nmea_rr teseo::gpgll("$PSTMNMEAREQUEST,100000,0\n\r", "$GPGLL,");
+nmea_rr teseo::gpgsv("$PSTMNMEAREQUEST,80000,0\n\r", "$GPGSV,");
 nmea_rr teseo::gprmc("$PSTMNMEAREQUEST,40,0\n\r", "$GPRMC,");
 
 
@@ -80,12 +81,21 @@ bool teseo::ask_nmea(const nmea_rr& command, std::string& s, uint retries) {
     return retval;
 }
 
+bool teseo::ask_nmea_multiple(const nmea_rr& command, std::vector<std::string>& strings, uint retries) {
+    return false; // TODO implement
+}
+
 bool teseo::ask_gpgll(std::string& s, uint retries) {
     return ask_nmea(gpgll, s, retries);
 }
 
+// TODO: ggsv returns multiple lines
+bool teseo::ask_gpgsv(std::vector<std::string>& strings, uint retries) {
+    return ask_nmea_multiple(gprmc, strings, retries);
+}
+
 bool teseo::ask_gprmc(std::string& s, uint retries) {
-    return ask_nmea(gprmc, s, retries);
+    return ask_nmea(gpgsv, s, retries);
 }
 
 } // namespace teseo

--- a/teseo/teseo.h
+++ b/teseo/teseo.h
@@ -25,6 +25,9 @@ typedef const std::pair<const std::string, const std::string> nmea_rr;
 class teseo {
 public:
 
+    //! constructor.
+    teseo() : single_line_parser(2) {}
+
     //! expose the callback manager for writing to Teseo.
     /*!
       The developer has to register the logic for writing to the device.  
@@ -83,6 +86,16 @@ public:
     */
     void init();
 
+    //! utility to parse a multiline Teseo reply into separate strings
+    /*!
+      \param s std::vector<qtd::string> reference will get the individual strings.  
+      \param s constant std::string reference string to be parsed.  
+      \returns count of strings parsed
+
+      split a big Teseo reply in its individual strings. The separator is "\r\n"
+    */
+    static uint parse_multiline_reply(std::vector<std::string> & strings, const std::string s) ;
+
     //! write command to the Teseo
     /*!
       \param s constant std::string reference.  
@@ -105,7 +118,7 @@ public:
     /*!
       \param command const nmea_rr reference holds the NMEA command.   
       \param s std::string reference gets the reply.  
-      \param retries int. Default: 1.  
+      \param retries int. Default: 0.  
       \returns bool true if valid reply
 
       Send NMEA request to the Teseo. Validate and Return the repy. Retry to get a valid reply
@@ -116,17 +129,16 @@ public:
     /*!
       \param command const nmea_rr reference holds the NMEA command.   
       \param strings std::vector<std::string> reference gets the replies.  
-      \param retries int. Default: 1.  
-      \returns bool true if valid reply
+      \returns uint count of replies
 
       Send NMEA request that expects more than 1 reply to the Teseo. Validate and Return the repies. Retry to get a valid reply
     */    
-    bool ask_nmea_multiple(const nmea_rr& command, std::vector<std::string>& strings, uint retries = 0);
+    uint ask_nmea_multiple(const nmea_rr& command, std::vector<std::string>& strings);
 
     //! get GPGLL request to the Teseo and read reply
     /*!
       \param s std::string reference gets the reply.  
-      \param retries int. Default: 1.  
+      \param retries int. Default: 0.  
       \returns bool true if valid reply  
 
       Send request for GPGLL data to the Teseo. Retrieve the repy.
@@ -136,17 +148,16 @@ public:
     //! get GPGSV request to the Teseo and read reply
     /*!
       \param s std::string reference gets the reply. 
-      \param retries int. Default: 1.  
-      \returns bool true if valid reply  
+      \returns int count of replies.
 
       Send request for GPGSV data to the Teseo. Retrieve the repy.
     */    
-    bool ask_gpgsv(std::vector<std::string>& strings, uint retries = 0);
+    uint ask_gpgsv(std::vector<std::string>& strings);
 
     //! get GPRMC request to the Teseo and read reply
     /*!
       \param s std::string reference gets the reply.  
-      \param retries int. Default: 1.  
+      \param retries int. Default: 0.  
       \returns bool true if valid reply  
 
       Send request for GPRMC data to the Teseo. Retrieve the repy.
@@ -167,6 +178,7 @@ private:
     Callback<void, std::string&> reader;
     //! callback manager for resetting the Teseo
     Callback<void> resetter;
+    std::vector<std::string> single_line_parser;
 
 };
 

--- a/teseo/teseo.h
+++ b/teseo/teseo.h
@@ -103,7 +103,7 @@ public:
 
     //! send NMEA request to the Teseo and return reply
     /*!
-      \param cmd const nmea_rr reference. 
+      \param command const nmea_rr reference. 
       \param s std::string reference. 
       \param retries int. Default: 1.
       \returns bool true if valid reply

--- a/teseo/teseo.h
+++ b/teseo/teseo.h
@@ -103,32 +103,53 @@ public:
 
     //! send NMEA request to the Teseo and return reply
     /*!
-      \param command const nmea_rr reference. 
-      \param s std::string reference. 
-      \param retries int. Default: 1.
+      \param command const nmea_rr reference holds the NMEA command.   
+      \param s std::string reference gets the reply.  
+      \param retries int. Default: 1.  
       \returns bool true if valid reply
 
       Send NMEA request to the Teseo. Validate and Return the repy. Retry to get a valid reply
     */    
     bool ask_nmea(const nmea_rr& command, std::string& s, uint retries = 0);
 
+    //! send NMEA request to the Teseo and return multi line reply
+    /*!
+      \param command const nmea_rr reference holds the NMEA command.   
+      \param strings std::vector<std::string> reference gets the replies.  
+      \param retries int. Default: 1.  
+      \returns bool true if valid reply
+
+      Send NMEA request that expects more than 1 reply to the Teseo. Validate and Return the repies. Retry to get a valid reply
+    */    
+    bool ask_nmea_multiple(const nmea_rr& command, std::vector<std::string>& strings, uint retries = 0);
+
     //! get GPGLL request to the Teseo and read reply
     /*!
-      \param s std::string reference. 
-      \param retries int. Default: 1.
-      \returns bool true if valid reply
+      \param s std::string reference gets the reply.  
+      \param retries int. Default: 1.  
+      \returns bool true if valid reply  
 
       Send request for GPGLL data to the Teseo. Retrieve the repy.
     */    
     bool ask_gpgll(std::string& s, uint retries = 0);
 
+    //! get GPGSV request to the Teseo and read reply
+    /*!
+      \param s std::string reference gets the reply. 
+      \param retries int. Default: 1.  
+      \returns bool true if valid reply  
+
+      Send request for GPGSV data to the Teseo. Retrieve the repy.
+    */    
+    bool ask_gpgsv(std::vector<std::string>& strings, uint retries = 0);
+
     //! get GPRMC request to the Teseo and read reply
     /*!
-      \param s std::string reference. 
-      \param retries int. Default: 1.
-      \returns bool true if valid reply
+      \param s std::string reference gets the reply.  
+      \param retries int. Default: 1.  
+      \returns bool true if valid reply  
 
-      Send request for RPRMC data to the Teseo. Retrieve the repy.
+      Send request for GPRMC data to the Teseo. Retrieve the repy.
     */    
     bool ask_gprmc(std::string& s, uint retries = 0);
 
@@ -136,6 +157,8 @@ private:
 
     //! command to retrieve GPGLL data
     static nmea_rr gpgll;
+    //! command to retrieve GPGSV data
+    static nmea_rr gpgsv;
     //! command to retrieve GPRMC data
     static nmea_rr gprmc;
     //! callback manager for writing to the Teseo


### PR DESCRIPTION
some commands, like GPGSV, return multiple lines.
I implemented parsing of those in the teseo class.

tested with the UART Pico reader, but not with the I2C reader.
I put an asset to make the multiline code fail on I2C, until tested