### PR TITLE
meaningful reply validation, i2c stabilised, clean up for initial release

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -54,10 +54,7 @@
 #define I2C_SDA (16)
 #define I2C_SCL (17)
 #define I2C_ADDR (0x3A)
-// multiline replies take decent buffer size
-// calculate 70 characters per satelite, + 60 for the status line
-// many libraries limit the number of satelites to say 7
-#define BUFFSIZE (70 * MAX_SATELITES + 60)
+#define BUFFSIZE (1024)
 #endif
 
 #ifdef GPS_OVER_UART
@@ -245,19 +242,21 @@ int main() {
     */
     gps.init();
     uint count; // intentionally uninitialised
+    bool valid; // intentionally uninitialised
 
     while (true) {
-        gps.ask_gpgll(reply, 4);
+        valid = gps.ask_gpgll(reply);
+        printf("valid: %s.\r\n", valid ? "yes" : "no");
         printf(reply.c_str());
 
-// #ifdef GPS_OVER_UART // not tested with I2C
-        gps.ask_gpgsv(replies, count);
+        valid = gps.ask_gpgsv(replies, count);
+        printf("valid: %s. count: %u.\r\n", valid ? "yes" : "no", count);
         for (auto &s : replies) {
             printf(s.c_str());
         }
-// #endif
 
-        gps.ask_gprmc(reply, 4);
+        valid = gps.ask_gprmc(reply);
+        printf("valid: %s.\r\n", valid ? "yes" : "no");
         printf(reply.c_str());
 
         printf("\r\n");

--- a/teseo/teseo.h
+++ b/teseo/teseo.h
@@ -90,12 +90,13 @@ public:
     /*!
       \param strings std::vector<qtd::string> reference will get the individual strings.  
       \param s constant std::string reference string to be parsed.  
-      \param count uint reference count of strings parsed.  
+      \param count uint reference gets count of strings parsed.  
+      \param command nmea_rr const reference used to validate the status line.  
       \returns  bool true if valid reply 
 
       split a big Teseo reply in its individual strings. The separator is "\r\n"
     */
-    static bool parse_multiline_reply(std::vector<std::string> & strings, const std::string s, uint& count) ;
+    static bool parse_multiline_reply(std::vector<std::string> & strings, const std::string s, uint& count, const nmea_rr& command) ;
 
     //! write command to the Teseo
     /*!
@@ -119,12 +120,11 @@ public:
     /*!
       \param command const nmea_rr reference holds the NMEA command.   
       \param s std::string reference gets the reply.  
-      \param retries int. Default: 0.  
       \returns bool true if valid reply
 
-      Send NMEA request to the Teseo. Validate and Return the repy. Retry to get a valid reply
+      Send NMEA request to the Teseo. Validate and Return the repy.
     */    
-    bool ask_nmea(const nmea_rr& command, std::string& s, uint retries = 0);
+    bool ask_nmea(const nmea_rr& command, std::string& s);
 
     //! send NMEA request to the Teseo and return multi line reply
     /*!
@@ -133,19 +133,18 @@ public:
       \param count uint reference count of strings parsed.  
       \returns  bool true if valid reply 
 
-      Send NMEA request that expects more than 1 reply to the Teseo. Validate and Return the repies. Retry to get a valid reply
+      Send NMEA request that expects more than 1 reply to the Teseo. Validate and Return the repies.
     */    
     bool ask_nmea_multiple(const nmea_rr& command, std::vector<std::string>& strings, uint& count);
 
     //! get GPGLL request to the Teseo and read reply
     /*!
       \param s std::string reference gets the reply.  
-      \param retries int. Default: 0.  
       \returns bool true if valid reply  
 
       Send request for GPGLL data to the Teseo. Retrieve the repy.
     */    
-    bool ask_gpgll(std::string& s, uint retries = 0);
+    bool ask_gpgll(std::string& s);
 
     //! get GPGSV request to the Teseo and read reply
     /*!
@@ -160,12 +159,11 @@ public:
     //! get GPRMC request to the Teseo and read reply
     /*!
       \param s std::string reference gets the reply.  
-      \param retries int. Default: 0.  
       \returns bool true if valid reply  
 
       Send request for GPRMC data to the Teseo. Retrieve the repy.
     */    
-    bool ask_gprmc(std::string& s, uint retries = 0);
+    bool ask_gprmc(std::string& s);
 
 private:
 
@@ -181,6 +179,7 @@ private:
     Callback<void, std::string&> reader;
     //! callback manager for resetting the Teseo
     Callback<void> resetter;
+    //! every single line NMEA command has two lines. reply and status
     std::vector<std::string> single_line_parser;
 
 };


### PR DESCRIPTION
- validate the NMEA status line
- I2C now stable, at cost of bigger buffer. Retry functionality removed
- include validation in the main example
- fully tested on a Raspberry Pico, with I2C and UART